### PR TITLE
Add disable js option

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Elao : Vagrant Extension",
-  "version": "0.0.2",
-  "manifest_version": 2,
+  "version": "0.0.3",
+  "manifest_version": 3,
   "description": "Extension to display available tools when running a project with the elao vagrant stack",
   "homepage_url": "https://github.com/Elao/symfony-standard-extension",
   "icons": {
@@ -19,7 +19,9 @@
     "default_popup": "popup.html"
   },
   "permissions": [
-    "http://*.dev/*"
+    "http://*.dev/*",
+    "contentSettings",
+    "notifications"
   ],
   "content_scripts": [
     {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Elao : Vagrant Extension",
   "version": "0.0.3",
-  "manifest_version": 3,
+  "manifest_version": 2,
   "description": "Extension to display available tools when running a project with the elao vagrant stack",
   "homepage_url": "https://github.com/Elao/symfony-standard-extension",
   "icons": {

--- a/src/popup.html
+++ b/src/popup.html
@@ -9,7 +9,7 @@
         <hr/>
         <ul id="utils" class="toolsList">
             <li><a href="#" id="removeValidation">Disable HTML5 validation</a></li>
-            <li><a href="#" id="disableJavascript">Toggle Javascript</a></li>
+            <li><a href="#" id="toggleJavascript">Toggle Javascript</a></li>
         </ul>
     </body>
 </html>

--- a/src/popup.html
+++ b/src/popup.html
@@ -9,7 +9,7 @@
         <hr/>
         <ul id="utils" class="toolsList">
             <li><a href="#" id="removeValidation">Disable HTML5 validation</a></li>
-            <li><a href="#" id="disableJavascript">Disable/Enable Javascript</a></li>
+            <li><a href="#" id="disableJavascript">Toggle Javascript</a></li>
         </ul>
     </body>
 </html>

--- a/src/popup.html
+++ b/src/popup.html
@@ -9,6 +9,7 @@
         <hr/>
         <ul id="utils" class="toolsList">
             <li><a href="#" id="removeValidation">Disable HTML5 validation</a></li>
+            <li><a href="#" id="disableJavascript">Disable/Enable Javascript</a></li>
         </ul>
     </body>
 </html>

--- a/src/popup.js
+++ b/src/popup.js
@@ -16,34 +16,36 @@ function displayTools(enabledTools) {
             chrome.tabs.sendMessage(tabs[0].id, {from: 'popup', subject: 'removeValidation'}, null);
         });
     });
-    var disableJavascript = document.getElementById('disableJavascript');
-    function updateButton(details)
-    {
-      disableJavascript.textContent = details.setting == 'allow' ? 'Disable Javascript' : 'Enable Javascript';
+
+    var toggleJavascript = document.getElementById('toggleJavascript');
+    function updateButtonContent(details){
+        toggleJavascript.textContent = details.setting == 'allow' ? 'Disable Javascript' : 'Enable Javascript';
     }
     chrome.contentSettings.javascript.get({
         'primaryUrl': 'http://*.dev/*'
-    }, updateButton );
+    }, updateButtonContent);
 
-    disableJavascript.addEventListener('click', function (event) {
+    toggleJavascript.addEventListener('click', function (event) {
         chrome.contentSettings.javascript.get({
             'primaryUrl': 'http://*.dev/*'
         }, function (details) {
-          updateButton(details);
-          var newSetting = details.setting == 'allow' ? 'block' : 'allow';
-          chrome.contentSettings.javascript.set({
-            'primaryPattern': 'http://*.dev/*',
-            'setting': newSetting,
-            'scope': 'regular'
-          });
-          chrome.notifications.create('javascript', {
-              'type': "basic",
-              'title': 'Javascript ' + newSetting + 'ed',
-              'iconUrl': "logo_action.png",
-              'message': "The javascript has been " + newSetting + "ed on the .dev pages"
-          });
-          // Reload the current tab for the change of javascript settings to apply
-          chrome.tabs.reload();
+            var newSetting = details.setting == 'allow' ? 'block' : 'allow';
+            chrome.contentSettings.javascript.set({
+                'primaryPattern': 'http://*.dev/*',
+                'setting': newSetting,
+                'scope': 'regular'
+            });
+            updateButtonContent(details);
+            chrome.notifications.create('javascript', {
+                'type': "basic",
+                'title': 'Javascript ' + newSetting + 'ed',
+                'iconUrl': "logo_action.png",
+                'message': "The javascript has been " + newSetting + "ed on the .dev pages"
+            });
+            // Close the popup
+            window.close();
+            // Reload the current tab for the change of javascript settings to apply
+            chrome.tabs.reload();
         });
     });
 

--- a/src/popup.js
+++ b/src/popup.js
@@ -16,6 +16,27 @@ function displayTools(enabledTools) {
             chrome.tabs.sendMessage(tabs[0].id, {from: 'popup', subject: 'removeValidation'}, null);
         });
     });
+    var disableJavascript = document.getElementById('disableJavascript');
+    disableJavascript.addEventListener('click', function (event) {
+        chrome.contentSettings.javascript.get({
+            'primaryUrl': 'http://*.dev/*'
+        }, function (details) {
+          var newSetting = details.setting == 'allow' ? 'block' : 'allow';
+          chrome.contentSettings.javascript.set({
+            'primaryPattern': 'http://*.dev/*',
+            'setting': newSetting,
+            'scope': 'regular'
+          });
+          chrome.notifications.create('javascript', {
+              'type': "basic",
+              'title': 'Javascript ' + newSetting + 'ed',
+              'iconUrl': "logo_action.png",
+              'message': "The javascript has been " + newSetting + "ed on the .dev pages"
+          });
+          // Reload the current tab for the change of javascript settings to apply
+          chrome.tabs.reload();
+        });
+    });
 
     links = document.querySelectorAll('#enabledTools a');
     for (var i in links) {

--- a/src/popup.js
+++ b/src/popup.js
@@ -17,10 +17,19 @@ function displayTools(enabledTools) {
         });
     });
     var disableJavascript = document.getElementById('disableJavascript');
+    function updateButton(details)
+    {
+      disableJavascript.textContent = details.setting == 'allow' ? 'Disable Javascript' : 'Enable Javascript';
+    }
+    chrome.contentSettings.javascript.get({
+        'primaryUrl': 'http://*.dev/*'
+    }, updateButton );
+
     disableJavascript.addEventListener('click', function (event) {
         chrome.contentSettings.javascript.get({
             'primaryUrl': 'http://*.dev/*'
         }, function (details) {
+          updateButton(details);
           var newSetting = details.setting == 'allow' ? 'block' : 'allow';
           chrome.contentSettings.javascript.set({
             'primaryPattern': 'http://*.dev/*',

--- a/src/popup.js
+++ b/src/popup.js
@@ -18,7 +18,7 @@ function displayTools(enabledTools) {
     });
 
     var toggleJavascript = document.getElementById('toggleJavascript');
-    function updateButtonContent(details){
+    function updateButtonContent(details) {
         toggleJavascript.textContent = details.setting == 'allow' ? 'Disable Javascript' : 'Enable Javascript';
     }
     chrome.contentSettings.javascript.get({


### PR DESCRIPTION
Addition of an entry in the tools to disable/enable Js:
<img width="228" alt="screen shot 2016-08-11 at 00 19 22" src="https://cloud.githubusercontent.com/assets/4649817/17573226/52d28de8-5f59-11e6-83c1-b5cc2ac09de2.png">

On click on `Disable/Enable Javascript` the settings is changed for the opposite, a notification is triggered to warn the user and the page is reloaded to apply the change
<img width="364" alt="screen shot 2016-08-11 at 00 14 57" src="https://cloud.githubusercontent.com/assets/4649817/17573254/830aad06-5f59-11e6-85e0-4b28abb587ca.png">

The usage of the notification could also be a nice addition for the `Disable HTML5 validation` as it does not "block" the user workflow, it just warns him that the change has been made
